### PR TITLE
Add PR Security Auto-Fix tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ This is the home for **free, open-source tools** built by and for the AI agent b
 | Tool | What It Does | Install |
 |------|-------------|---------|
 | **[SEO/GEO Auto-Fix Reviewer](seo-geo-reviewer/)** | AI-powered GitHub Action that reviews PRs for SEO issues and auto-fixes them. Uses GPT-5.4 or Claude. | `npx agentmag add tool seo-geo-reviewer` |
+| **[PR Security Auto-Fix](pr-security-auto-fix/)** | AI-powered GitHub Action that reviews pull requests for security issues and commits safe fixes automatically. Uses GPT-5.4 or Claude. | `npx agentmag add tool pr-security-auto-fix` |
 | **[Agent Sounds](agent-sounds/)** | Sound effects for Claude Code sessions — hear audio cues when tasks start, complete, or need attention. 4 original royalty-free sound packs. | `npx agentmag add tool claude-sounds` |
 
 ---

--- a/pr-security-auto-fix/README.md
+++ b/pr-security-auto-fix/README.md
@@ -1,0 +1,205 @@
+<div align="center">
+
+<a href="https://theagentmag.com"><img src="https://theagentmag.com/brand/agentmag-banner-github.png" alt="Agent Mag" width="540" /></a>
+
+<br /><br />
+
+# PR Security Auto-Fix
+
+**AI-powered GitHub Action that reviews pull requests for security issues and commits safe fixes automatically.**
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-000?style=for-the-badge)](../LICENSE)
+[![Agent Mag](https://img.shields.io/badge/by-Agent_Mag-000?style=for-the-badge)](https://theagentmag.com)
+
+</div>
+
+---
+
+## What It Does
+
+PR Security Auto-Fix runs on pull requests and:
+
+1. **Scans changed files** for high-confidence security vulnerabilities
+2. **Filters noise** so it avoids generic hardening and theoretical findings
+3. **Produces safe patches** for small, local fixes
+4. **Commits fixes** directly to trusted PR branches
+5. **Posts a branded PR comment** with verdict, exploit path, recommendations, and fix summary
+
+It is intentionally conservative. The action reports concrete exploit paths and only auto-fixes changes it can validate with exact search-and-replace patches.
+
+## Quick Start
+
+### Option A: One command via Agent Mag
+
+```bash
+npx agentmag add tool pr-security-auto-fix
+```
+
+This scaffolds `.github/workflows/pr-security-auto-fix.yml`. Add the required model secret(s), then open a pull request.
+
+### Option B: Manual setup
+
+```yaml
+name: PR Security Auto-Fix
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: pr-security-auto-fix-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  security:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Skip auto-fix commits
+        id: skip-check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          MSG=$(gh api repos/${{ github.repository }}/commits/${{ github.event.pull_request.head.sha }} --jq '.commit.message' 2>/dev/null || echo "")
+          if echo "$MSG" | grep -q "^fix(security): auto-fix PR security issues"; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout
+        if: steps.skip-check.outputs.skip != 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Setup Python
+        if: steps.skip-check.outputs.skip != 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: PR Security Auto-Fix
+        if: steps.skip-check.outputs.skip != 'true'
+        uses: Agent-mag/tools/pr-security-auto-fix@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pr-number: ${{ github.event.pull_request.number }}
+          base-sha: ${{ github.event.pull_request.base.sha }}
+          head-sha: ${{ github.event.pull_request.head.sha }}
+          azure-openai-endpoint: ${{ secrets.AZURE_OPENAI_GPT54_ENDPOINT }}
+          azure-openai-deployment: ${{ secrets.AZURE_OPENAI_GPT54_DEPLOYMENT }}
+          azure-openai-api-version: ${{ secrets.AZURE_OPENAI_GPT54_API_VERSION }}
+          azure-openai-api-key: ${{ secrets.AZURE_OPENAI_GPT54_KEY }}
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          validation-command: "npm run lint"
+```
+
+## Model Support
+
+| Provider | Model | Config |
+|----------|-------|--------|
+| **Azure OpenAI** (primary) | GPT-5.4 | `azure-openai-endpoint`, `azure-openai-deployment`, `azure-openai-api-key` |
+| **Anthropic** (fallback) | Claude Opus 4.6 | `anthropic-api-key` |
+
+Use either provider or both. Azure runs first when configured.
+
+## What Gets Reviewed
+
+PR Security Auto-Fix focuses on high-confidence vulnerabilities:
+
+- SQL/NoSQL/command/template/path injection
+- Authentication and authorization bypasses
+- Tenant isolation failures
+- Sensitive data exposure
+- Unsafe HTML rendering and concrete XSS
+- SSRF with attacker-controlled host/protocol
+- Weak crypto in security-sensitive flows
+- Dangerous GitHub Actions patterns
+- AI-agent tool abuse paths
+
+It deliberately skips noisy categories like DoS, generic rate limiting, missing audit logs, docs-only findings, test-only files, dependency CVEs, and theoretical hardening.
+
+## What Gets Auto-Fixed
+
+Auto-fixes are limited to small, local patches:
+
+- Add obvious server-side auth checks using existing helpers
+- Parameterize query or shell sinks
+- Redact sensitive logging
+- Validate SSRF/redirect targets
+- Restrict unsafe CORS/allowlists
+- Replace unsafe HTML sinks with escaped/sanitized output
+
+Every patch must:
+
+- Match an exact unique `search` string
+- Map to a surviving HIGH or MEDIUM finding
+- Have confidence of at least `0.85`
+- Touch only changed source/config files
+- Pass `validation-command` when configured
+
+## Security Boundary
+
+This action is designed for trusted PRs. By default, `trusted-only: true` skips forked PRs before model calls or writes. Do not run this with `pull_request_target` against untrusted code.
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `github-token` | Yes | — | Token with `contents:write` + `pull-requests:write` |
+| `pr-number` | Yes | — | PR number |
+| `base-sha` | Yes | — | PR base SHA |
+| `head-sha` | Yes | — | PR head SHA |
+| `azure-openai-endpoint` | No | — | Azure OpenAI endpoint URL |
+| `azure-openai-deployment` | No | — | Azure OpenAI deployment name |
+| `azure-openai-api-version` | No | `2025-04-01-preview` | Azure API version |
+| `azure-openai-api-key` | No | — | Azure OpenAI API key |
+| `anthropic-api-key` | No | — | Anthropic API key |
+| `comment-pr` | No | `true` | Post/update PR comment |
+| `auto-fix` | No | `true` | Commit safe fixes to trusted PR branch |
+| `trusted-only` | No | `true` | Skip forked PRs |
+| `max-patches` | No | `5` | Max auto-fixes per run |
+| `validation-command` | No | — | Command to run before committing patches |
+| `exclude-directories` | No | — | Comma-separated extra directories to skip |
+| `custom-security-scan-instructions` | No | — | Extra scan prompt file |
+| `false-positive-filtering-instructions` | No | — | Extra false-positive prompt file |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `findings-count` | Remaining findings after auto-fix |
+| `summary` | Summary string |
+| `verdict` | `APPROVE`, `COMMENT`, or `REQUEST_CHANGES` |
+| `results-file` | `pr-security-auto-fix-findings.json` |
+
+## Customizing Rules
+
+Fork this repo and edit:
+
+- `rules/security-review.md`
+- `rules/auto-fix.md`
+- `rules/false-positives.md`
+- `rules/language-patterns.md`
+
+## License
+
+MIT — see [LICENSE](../LICENSE).
+
+---
+
+<div align="center">
+
+**Built by [Agent Mag](https://theagentmag.com)** — the magazine for AI agent builders.
+
+</div>

--- a/pr-security-auto-fix/action.yml
+++ b/pr-security-auto-fix/action.yml
@@ -1,0 +1,127 @@
+name: "Agent Mag PR Security Auto-Fix"
+description: >
+  AI-powered PR security review that finds high-confidence vulnerabilities,
+  commits safe auto-fixes, and posts a branded pull request summary.
+author: "Agent Mag"
+branding:
+  icon: "shield"
+  color: "gray-dark"
+
+inputs:
+  github-token:
+    description: "GITHUB_TOKEN with contents:write + pull-requests:write"
+    required: true
+  pr-number:
+    description: "Pull request number"
+    required: true
+  base-sha:
+    description: "PR base SHA"
+    required: true
+  head-sha:
+    description: "PR head SHA"
+    required: true
+  azure-openai-endpoint:
+    description: "Azure OpenAI endpoint"
+    required: false
+  azure-openai-deployment:
+    description: "Azure OpenAI deployment name"
+    required: false
+  azure-openai-api-version:
+    description: "Azure OpenAI API version"
+    required: false
+    default: "2025-04-01-preview"
+  azure-openai-api-key:
+    description: "Azure OpenAI API key"
+    required: false
+  anthropic-api-key:
+    description: "Anthropic API key (fallback, or primary if no Azure)"
+    required: false
+  comment-pr:
+    description: "Post or update a PR comment"
+    required: false
+    default: "true"
+  auto-fix:
+    description: "Commit safe auto-fix patches to the PR branch"
+    required: false
+    default: "true"
+  trusted-only:
+    description: "Skip forked/untrusted PRs before model calls or writes"
+    required: false
+    default: "true"
+  max-patches:
+    description: "Maximum number of patches the action may apply in one run"
+    required: false
+    default: "5"
+  validation-command:
+    description: "Optional command to run after applying patches locally, before committing"
+    required: false
+    default: ""
+  exclude-directories:
+    description: "Comma-separated directories to exclude from scanning"
+    required: false
+    default: ""
+  custom-security-scan-instructions:
+    description: "Path to custom security scan instructions to append to the prompt"
+    required: false
+    default: ""
+  false-positive-filtering-instructions:
+    description: "Path to custom false-positive filtering instructions to append to the prompt"
+    required: false
+    default: ""
+
+outputs:
+  findings-count:
+    description: "Total remaining findings after auto-fix"
+    value: ${{ steps.review.outputs.findings_count }}
+  summary:
+    description: "Summary string (high/medium/low)"
+    value: ${{ steps.review.outputs.summary }}
+  verdict:
+    description: "APPROVE, COMMENT, or REQUEST_CHANGES"
+    value: ${{ steps.review.outputs.verdict }}
+  results-file:
+    description: "Path to JSON results"
+    value: pr-security-auto-fix-findings.json
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Python dependencies
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r ${{ github.action_path }}/requirements.txt
+
+    - name: Run PR Security Auto-Fix Review
+      id: review
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+        PR_NUMBER: ${{ inputs.pr-number }}
+        BASE_SHA: ${{ inputs.base-sha }}
+        HEAD_SHA: ${{ inputs.head-sha }}
+        AZURE_OPENAI_ENDPOINT: ${{ inputs.azure-openai-endpoint }}
+        AZURE_OPENAI_DEPLOYMENT: ${{ inputs.azure-openai-deployment }}
+        AZURE_OPENAI_API_VERSION: ${{ inputs.azure-openai-api-version }}
+        AZURE_OPENAI_API_KEY: ${{ inputs.azure-openai-api-key }}
+        ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
+        COMMENT_PR: ${{ inputs.comment-pr }}
+        AUTO_FIX: ${{ inputs.auto-fix }}
+        TRUSTED_ONLY: ${{ inputs.trusted-only }}
+        MAX_PATCHES: ${{ inputs.max-patches }}
+        VALIDATION_COMMAND: ${{ inputs.validation-command }}
+        EXCLUDE_DIRECTORIES: ${{ inputs.exclude-directories }}
+        CUSTOM_SECURITY_SCAN_INSTRUCTIONS: ${{ inputs.custom-security-scan-instructions }}
+        FALSE_POSITIVE_FILTERING_INSTRUCTIONS: ${{ inputs.false-positive-filtering-instructions }}
+        ACTION_PATH: ${{ github.action_path }}
+      run: |
+        python "${{ github.action_path }}/review.py"
+
+    - name: Upload findings artifact
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: pr-security-auto-fix-findings
+        path: pr-security-auto-fix-findings.json
+        if-no-files-found: ignore

--- a/pr-security-auto-fix/filters.py
+++ b/pr-security-auto-fix/filters.py
@@ -1,0 +1,108 @@
+"""
+False-positive filtering and verdict helpers for PR Security Auto-Fix.
+
+The model should already be conservative. These regex filters are a second
+guardrail so the PR comment stays useful instead of turning into generic
+"security best practices" noise.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+
+MIN_REPORT_CONFIDENCE = 0.8
+
+FP_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"\bdenial of service\b|\bDoS\b|resource exhaustion|rate limit", re.IGNORECASE),
+    re.compile(r"missing audit logs?|lack of logging|add audit", re.IGNORECASE),
+    re.compile(r"open redirect", re.IGNORECASE),
+    re.compile(r"tabnabbing|xs-leaks?|clickjacking", re.IGNORECASE),
+    re.compile(r"prototype pollution", re.IGNORECASE),
+    re.compile(r"regex injection|regular expression denial|ReDoS", re.IGNORECASE),
+    re.compile(r"outdated dependency|vulnerable dependency|CVE", re.IGNORECASE),
+    re.compile(r"documentation|readme|markdown", re.IGNORECASE),
+    re.compile(r"client-side authorization|client side authorization", re.IGNORECASE),
+    re.compile(r"React.*XSS|Angular.*XSS", re.IGNORECASE),
+    re.compile(r"environment variables?.*attacker", re.IGNORECASE),
+    re.compile(r"prompt injection.*not.*tool|AI prompt.*not.*secret", re.IGNORECASE),
+    re.compile(r"log spoofing|logs? untrusted input", re.IGNORECASE),
+]
+
+EXCLUDE_PATH_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"^node_modules/"),
+    re.compile(r"^vendor/"),
+    re.compile(r"^\.next/"),
+    re.compile(r"^dist/"),
+    re.compile(r"^build/"),
+    re.compile(r"^coverage/"),
+    re.compile(r"^\.git/"),
+    re.compile(r"package-lock\.json$"),
+    re.compile(r"pnpm-lock\.yaml$"),
+    re.compile(r"yarn\.lock$"),
+    re.compile(r"\.lock$"),
+    re.compile(r"\.(md|mdx|txt|rst)$", re.IGNORECASE),
+    re.compile(r"(^|/)(test|tests|__tests__|fixtures?|mocks?)/", re.IGNORECASE),
+    re.compile(r"(\.test|\.spec)\.(js|jsx|ts|tsx|py|go|rs)$", re.IGNORECASE),
+    re.compile(r"^public/"),
+    re.compile(r"^assets?/"),
+    re.compile(r"\.(png|jpe?g|gif|webp|svg|ico|pdf|woff2?|ttf|otf)$", re.IGNORECASE),
+]
+
+
+def is_excluded_path(path: str) -> bool:
+    return any(pattern.search(path) for pattern in EXCLUDE_PATH_PATTERNS)
+
+
+def _confidence(finding: dict[str, Any]) -> float:
+    raw = finding.get("confidence", 0)
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return 0.0
+    return value / 10 if value > 1 else value
+
+
+def matches_fp(finding: dict[str, Any]) -> bool:
+    text = " ".join(
+        str(finding.get(key, ""))
+        for key in ("rule", "issue", "description", "exploit_scenario", "recommendation", "file")
+    )
+    return any(pattern.search(text) for pattern in FP_PATTERNS)
+
+
+def filter_findings(findings: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Drop low-confidence and known-noise findings."""
+    kept: list[dict[str, Any]] = []
+    for finding in findings:
+        file_path = str(finding.get("file", ""))
+        if file_path and is_excluded_path(file_path):
+            continue
+        if _confidence(finding) < MIN_REPORT_CONFIDENCE:
+            continue
+        if matches_fp(finding):
+            continue
+        kept.append(finding)
+    return kept
+
+
+def recount_summary(findings: list[dict[str, Any]]) -> dict[str, int]:
+    summary = {"high": 0, "medium": 0, "low": 0}
+    for finding in findings:
+        sev = str(finding.get("severity", "")).upper()
+        if sev == "HIGH":
+            summary["high"] += 1
+        elif sev == "MEDIUM":
+            summary["medium"] += 1
+        elif sev == "LOW":
+            summary["low"] += 1
+    return summary
+
+
+def compute_verdict(summary: dict[str, int]) -> str:
+    if summary["high"] >= 1:
+        return "REQUEST_CHANGES"
+    if summary["medium"] >= 1:
+        return "COMMENT"
+    return "APPROVE"

--- a/pr-security-auto-fix/fixer.py
+++ b/pr-security-auto-fix/fixer.py
@@ -1,0 +1,99 @@
+"""
+GitHub Git Data API fixer for PR Security Auto-Fix.
+
+The action validates exact search/replace patches before this module is called.
+This module keeps the write path atomic: create blobs, build a tree, create one
+commit, then move the PR branch ref forward without force-push.
+"""
+
+from __future__ import annotations
+
+import base64
+from dataclasses import dataclass
+from typing import Any
+
+from github.Repository import Repository
+
+
+@dataclass
+class Patch:
+    file: str
+    search: str
+    replace: str
+    finding_id: str = ""
+    reason: str = ""
+
+
+def apply_to_contents(file_contents: dict[str, str], patches: list[Patch]) -> dict[str, str]:
+    """Return modified file contents after applying exact unique patches."""
+    patches_by_file: dict[str, list[Patch]] = {}
+    for patch in patches:
+        patches_by_file.setdefault(patch.file, []).append(patch)
+
+    modified_contents: dict[str, str] = {}
+    for filepath, file_patches in patches_by_file.items():
+        content = file_contents[filepath]
+        for patch in file_patches:
+            count = content.count(patch.search)
+            if count == 0:
+                raise ValueError(f"Search string not found in {filepath}: {patch.search[:80]}...")
+            if count > 1:
+                raise ValueError(f"Search string ambiguous ({count} matches) in {filepath}: {patch.search[:80]}...")
+            content = content.replace(patch.search, patch.replace, 1)
+        modified_contents[filepath] = content
+    return modified_contents
+
+
+def apply_patches(
+    repo: Repository,
+    branch: str,
+    base_sha: str,
+    patches: list[Patch],
+    file_contents: dict[str, str],
+    commit_message: str,
+) -> str:
+    """Apply patches and commit to branch. Returns the new commit SHA."""
+    modified_contents = apply_to_contents(file_contents, patches)
+
+    if not modified_contents:
+        raise ValueError("No files to patch")
+
+    base_commit = repo.get_git_commit(base_sha)
+    base_tree_sha = base_commit.tree.sha
+
+    tree_elements: list[dict[str, Any]] = []
+    for filepath, content in modified_contents.items():
+        blob = repo.create_git_blob(
+            content=base64.b64encode(content.encode("utf-8")).decode("ascii"),
+            encoding="base64",
+        )
+        tree_elements.append({
+            "path": filepath,
+            "mode": "100644",
+            "type": "blob",
+            "sha": blob.sha,
+        })
+
+    from github.InputGitTreeElement import InputGitTreeElement
+
+    tree_inputs = [
+        InputGitTreeElement(
+            path=el["path"],
+            mode=el["mode"],
+            type=el["type"],
+            sha=el["sha"],
+        )
+        for el in tree_elements
+    ]
+    new_tree = repo.create_git_tree(tree_inputs, base_tree=repo.get_git_tree(base_tree_sha))
+
+    new_commit = repo.create_git_commit(
+        message=commit_message,
+        tree=new_tree,
+        parents=[base_commit],
+    )
+
+    ref = repo.get_git_ref(f"heads/{branch}")
+    ref.edit(sha=new_commit.sha, force=False)
+
+    return new_commit.sha

--- a/pr-security-auto-fix/prompts.py
+++ b/pr-security-auto-fix/prompts.py
@@ -1,0 +1,202 @@
+"""
+Prompt and rulebook helpers for PR Security Auto-Fix.
+"""
+
+from pathlib import Path
+
+
+SYSTEM_PROMPT = """You are a principal application security engineer who reviews pull requests and AUTO-FIXES concrete vulnerabilities.
+
+# Your job
+Review only the code changed by this PR. Find high-confidence vulnerabilities with a real exploit path, then produce minimal search-and-replace patches for issues that can be fixed safely.
+
+This is not a general code review and not a hardening checklist. Avoid noisy best-practice findings. Prefer missing a theoretical issue over flooding the PR with weak findings.
+
+# Security categories to examine
+- Injection: SQL, NoSQL, command, template, XML/XXE, deserialization, path traversal.
+- Authentication and authorization: bypasses, privilege escalation, broken access checks, unsafe session/JWT handling.
+- Sensitive data exposure: leaking secrets, tokens, passwords, PII, or tenant data to clients/logs/errors.
+- XSS and unsafe rendering: only when an unsafe HTML sink exists, such as dangerouslySetInnerHTML or equivalent.
+- SSRF: only when attacker-controlled input can affect host or protocol.
+- Crypto and randomness: weak signing/encryption, predictable security tokens, certificate validation bypass.
+- Insecure configuration: permissive CORS, debug endpoints, public admin surfaces, unsafe GitHub Action triggers.
+- AI-agent risks: untrusted user/model content reaching privileged tools, shell commands, external fetches, secrets, or file writes without a concrete guard.
+
+# Hard exclusions
+Do NOT report:
+- Denial of service, rate limiting, memory/CPU exhaustion, regex DoS, or resource leaks.
+- Documentation-only issues.
+- Test-only or fixture-only issues.
+- Generic input validation without a specific security impact.
+- Open redirects, tabnabbing, XS-Leaks, log spoofing, lack of audit logs, or generic hardening.
+- Outdated dependencies or CVEs. Dependency scanning is handled elsewhere.
+- React/Angular XSS unless code uses an unsafe rendering bypass.
+- Client-side auth checks as vulnerabilities unless the server also trusts them.
+- Environment-variable attacks. Treat env vars and workflow secrets as trusted configuration.
+- Prompt injection by itself. Only report it if it creates a concrete path to privileged data/tool execution.
+
+# Auto-fix rules
+You are allowed to output patches only when the fix is small, local, and low-risk.
+
+Good patches:
+- Add server-side authorization checks when the local pattern is obvious.
+- Parameterize a query or safely escape a command argument.
+- Restrict an unsafe allowlist, CORS origin, redirect target, or SSRF URL validation.
+- Remove sensitive logging or redact secrets.
+- Replace unsafe HTML rendering with sanitized/escaped rendering when the existing dependency/pattern is clear.
+- Add validation directly at a newly introduced dangerous sink.
+
+Do not output patches that require broad refactors, new dependencies, migrations, large rewrites, or guessing business rules. Report those as findings without a patch.
+
+Patch requirements:
+- `search` must be copied exactly from the provided file content.
+- `search` must be unique in the file.
+- `replace` must compile and preserve intended behavior.
+- Patch only changed files.
+- Never patch lockfiles, docs, tests, generated files, public assets, or GitHub workflow files.
+- Every patch must map to a finding via `finding_id`.
+
+# Severity
+- HIGH: concrete exploit can lead to RCE, auth bypass, privilege escalation, secret/PII/tenant data exposure, or direct account/data compromise.
+- MEDIUM: concrete exploit has meaningful impact but requires conditions, limited privileges, or narrower data exposure.
+- LOW: defense-in-depth only. Include sparingly and never patch automatically unless trivial.
+
+# Confidence
+Use confidence from 0.0 to 1.0.
+- 0.90-1.00: clear exploit path, strong evidence.
+- 0.80-0.89: likely vulnerability with specific exploit conditions.
+- Below 0.80: do not report.
+
+# Output
+Return exactly one JSON object and no markdown fences:
+
+{
+  "summary": { "high": <int>, "medium": <int>, "low": <int> },
+  "findings": [
+    {
+      "id": "SEC-001",
+      "file": "<relative path>",
+      "line": <int or null>,
+      "severity": "HIGH" | "MEDIUM" | "LOW",
+      "confidence": <float 0.0-1.0>,
+      "category": "injection" | "authz" | "authn" | "data-exposure" | "xss" | "ssrf" | "crypto" | "config" | "supply-chain" | "ai-agent-risk",
+      "rule": "<kebab-case rule id>",
+      "issue": "<1-2 sentence issue>",
+      "exploit_scenario": "<specific exploit path>",
+      "recommendation": "<specific fix>"
+    }
+  ],
+  "patches": [
+    {
+      "finding_id": "SEC-001",
+      "file": "<relative path>",
+      "search": "<exact unique substring from file>",
+      "replace": "<replacement text>",
+      "reason": "<why this fixes the vulnerability>"
+    }
+  ],
+  "positives": [ "<specific secure pattern in this PR>" ],
+  "overall_verdict": "APPROVE" | "REQUEST_CHANGES" | "COMMENT"
+}
+"""
+
+
+def load_rulebook(action_path: str) -> str:
+    """Load all security rulebook markdown files."""
+    rules_dir = Path(action_path) / "rules"
+    parts: list[str] = []
+    for name in [
+        "security-review.md",
+        "auto-fix.md",
+        "false-positives.md",
+        "language-patterns.md",
+    ]:
+        path = rules_dir / name
+        if path.exists():
+            parts.append(f"\n\n===== {name} =====\n\n{path.read_text()}")
+    return "".join(parts)
+
+
+def read_optional_instruction(action_path: str, raw_path: str) -> str:
+    """Read a custom instruction file from the workspace or action directory."""
+    if not raw_path:
+        return ""
+
+    path = Path(raw_path)
+    candidates = [path]
+    if not path.is_absolute():
+        candidates.append(Path.cwd() / path)
+        candidates.append(Path(action_path) / path)
+
+    for candidate in candidates:
+        try:
+            if candidate.exists() and candidate.is_file():
+                return candidate.read_text()
+        except OSError:
+            continue
+    return ""
+
+
+def build_user_prompt(
+    repo_full_name: str,
+    pr_title: str,
+    pr_body: str,
+    pr_number: int,
+    diff_text: str,
+    changed_files: list[str],
+    file_contents: dict[str, str],
+    rulebook: str,
+    custom_scan_instructions: str = "",
+    false_positive_instructions: str = "",
+) -> str:
+    """Build the review + auto-fix request."""
+    files_list = "\n".join(f"- {path}" for path in changed_files)
+    content_blocks: list[str] = []
+    for path, content in file_contents.items():
+        content_blocks.append(f"===== {path} =====\n{content}\n===== END {path} =====")
+    full_contents = "\n\n".join(content_blocks)
+
+    extra = ""
+    if custom_scan_instructions.strip():
+        extra += f"\n\n# Custom security scan instructions\n\n{custom_scan_instructions.strip()}\n"
+    if false_positive_instructions.strip():
+        extra += f"\n\n# Custom false-positive filtering instructions\n\n{false_positive_instructions.strip()}\n"
+
+    return f"""# Pull Request Context
+
+- Repository: {repo_full_name}
+- PR #{pr_number}: {pr_title}
+- Description: {pr_body or "(empty)"}
+
+# Changed files
+
+{files_list}
+
+# Rulebook
+
+Apply these rules. Do not create findings for anything the rulebook excludes.
+
+{rulebook}
+{extra}
+
+# Full changed file contents
+
+Use these contents to understand context and to copy exact patch search strings.
+
+{full_contents}
+
+# Unified diff
+
+Review only vulnerabilities introduced or materially changed in this diff.
+
+```diff
+{diff_text}
+```
+
+# Task
+
+1. Identify concrete security vulnerabilities introduced by this PR.
+2. Assign HIGH/MEDIUM/LOW severity and confidence.
+3. Output patches only for safe, local fixes in changed files.
+4. Keep findings high-signal. Do not report confidence below 0.80.
+5. Output only the JSON object."""

--- a/pr-security-auto-fix/requirements.txt
+++ b/pr-security-auto-fix/requirements.txt
@@ -1,0 +1,4 @@
+openai>=1.50.0
+anthropic>=0.40.0
+PyGithub>=2.4.0
+requests>=2.32.0

--- a/pr-security-auto-fix/review.py
+++ b/pr-security-auto-fix/review.py
@@ -1,0 +1,748 @@
+#!/usr/bin/env python3
+"""
+Agent Mag PR Security Auto-Fix.
+
+Pipeline:
+1. Fetch PR metadata and changed files via GitHub API.
+2. Filter to security-relevant files.
+3. Chunk changed file contents + diffs for model limits.
+4. Call Azure OpenAI GPT-5.4, with Anthropic fallback.
+5. Parse structured JSON findings and safe patches.
+6. Apply false-positive filtering and patch validation.
+7. Optionally apply patches locally and run a validation command.
+8. Commit validated patches to the PR branch via GitHub Git Data API.
+9. Post/update a branded PR comment and upload JSON results.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+from github import Github
+from github.PullRequest import PullRequest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from filters import compute_verdict, filter_findings, recount_summary, is_excluded_path
+from fixer import Patch, apply_patches, apply_to_contents
+from prompts import SYSTEM_PROMPT, build_user_prompt, load_rulebook, read_optional_instruction
+
+RESULTS_FILE = "pr-security-auto-fix-findings.json"
+COMMENT_MARKER = "<!-- agent-mag-pr-security-auto-fix -->"
+
+REVIEWABLE_EXTENSIONS = (
+    ".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs",
+    ".py", ".rb", ".php", ".go", ".rs", ".java", ".kt", ".kts",
+    ".cs", ".scala", ".swift", ".c", ".cc", ".cpp", ".h", ".hpp",
+    ".sql", ".graphql", ".gql", ".json", ".yaml", ".yml", ".toml",
+    ".tf", ".tfvars", ".sh", ".bash", ".zsh", ".ps1",
+)
+
+REVIEWABLE_FILENAMES = {
+    "Dockerfile",
+    "Containerfile",
+    "docker-compose.yml",
+    "docker-compose.yaml",
+    "next.config.js",
+    "next.config.mjs",
+    "next.config.ts",
+    "vite.config.js",
+    "vite.config.ts",
+    "package.json",
+    "requirements.txt",
+    "pyproject.toml",
+    "go.mod",
+    "Cargo.toml",
+}
+
+NEVER_PATCH_PREFIXES = (
+    ".github/",
+    "docs/",
+    "public/",
+    "assets/",
+)
+
+DEFAULT_EXCLUDE_DIRECTORIES = (
+    "node_modules/",
+    "vendor/",
+    ".next/",
+    "dist/",
+    "build/",
+    "coverage/",
+)
+
+MIN_PATCH_CONFIDENCE = 0.85
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.lower() in {"1", "true", "yes", "on"}
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, str(default)))
+    except ValueError:
+        return default
+
+
+def _confidence(value: Any) -> float:
+    try:
+        score = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    return score / 10 if score > 1 else score
+
+
+def _normalize_exclude_dirs(raw: str) -> list[str]:
+    dirs = list(DEFAULT_EXCLUDE_DIRECTORIES)
+    for part in raw.split(","):
+        cleaned = part.strip().lstrip("./")
+        if not cleaned:
+            continue
+        dirs.append(cleaned if cleaned.endswith("/") else f"{cleaned}/")
+    return dirs
+
+
+def _is_reviewable_path(path: str, exclude_dirs: list[str]) -> bool:
+    normalized = path.lstrip("./")
+    if any(normalized.startswith(prefix) for prefix in exclude_dirs):
+        return False
+    if is_excluded_path(normalized):
+        return False
+    name = Path(normalized).name
+    if name in REVIEWABLE_FILENAMES:
+        return True
+    return normalized.endswith(REVIEWABLE_EXTENSIONS)
+
+
+def _is_patchable_path(path: str, changed_paths: set[str]) -> bool:
+    normalized = path.lstrip("./")
+    if normalized not in changed_paths:
+        return False
+    if any(normalized.startswith(prefix) for prefix in NEVER_PATCH_PREFIXES):
+        return False
+    if is_excluded_path(normalized):
+        return False
+    name = Path(normalized).name
+    return name in REVIEWABLE_FILENAMES or normalized.endswith(REVIEWABLE_EXTENSIONS)
+
+
+def filter_changed_files(files: list[dict[str, Any]], exclude_dirs: list[str]) -> list[dict[str, Any]]:
+    kept: list[dict[str, Any]] = []
+    for file in files:
+        filename = str(file.get("filename", ""))
+        if not filename:
+            continue
+        if file.get("status") == "removed":
+            continue
+        if _is_reviewable_path(filename, exclude_dirs):
+            kept.append(file)
+    return kept
+
+
+def fetch_file_contents(repo, ref: str, filepaths: list[str], max_file_chars: int = 28_000) -> dict[str, str]:
+    contents: dict[str, str] = {}
+    for filepath in filepaths:
+        try:
+            content_file = repo.get_contents(filepath, ref=ref)
+            if isinstance(content_file, list):
+                continue
+            if content_file.encoding == "base64":
+                import base64
+
+                text = base64.b64decode(content_file.content).decode("utf-8", errors="replace")
+            else:
+                text = content_file.decoded_content.decode("utf-8", errors="replace")
+            if len(text) > max_file_chars:
+                text = text[:max_file_chars] + "\n\n/* ... truncated by PR Security Auto-Fix ... */\n"
+            contents[filepath] = text
+        except Exception as exc:
+            print(f"Unable to fetch {filepath}: {exc}")
+            continue
+    return contents
+
+
+def build_diff_text(files: list[dict[str, Any]], max_chars: int = 24_000) -> str:
+    chunks: list[str] = []
+    total = 0
+    for file in files:
+        filename = str(file.get("filename", ""))
+        patch = file.get("patch", "") or ""
+        if not patch:
+            continue
+        block = f"diff --git a/{filename} b/{filename}\n{patch}\n"
+        if total + len(block) > max_chars:
+            chunks.append(f"\n... truncated at {max_chars} chars ...\n")
+            break
+        chunks.append(block)
+        total += len(block)
+    return "".join(chunks)
+
+
+def chunk_files(files: list[dict[str, Any]], file_contents: dict[str, str], max_chars: int) -> list[list[dict[str, Any]]]:
+    chunks: list[list[dict[str, Any]]] = []
+    current: list[dict[str, Any]] = []
+    current_size = 0
+
+    for file in files:
+        filename = str(file.get("filename", ""))
+        size = len(file_contents.get(filename, "")) + len(file.get("patch", "") or "") + 600
+        if current and current_size + size > max_chars:
+            chunks.append(current)
+            current = []
+            current_size = 0
+        current.append(file)
+        current_size += size
+
+    if current:
+        chunks.append(current)
+    return chunks
+
+
+def call_azure_openai(system: str, user: str) -> str:
+    from openai import AzureOpenAI
+
+    endpoint = os.environ.get("AZURE_OPENAI_ENDPOINT", "").rstrip("/")
+    deployment = os.environ.get("AZURE_OPENAI_DEPLOYMENT", "")
+    api_version = os.environ.get("AZURE_OPENAI_API_VERSION", "2025-04-01-preview")
+    api_key = os.environ.get("AZURE_OPENAI_API_KEY", "")
+
+    if not (endpoint and deployment and api_key):
+        raise RuntimeError("Azure OpenAI env vars not configured")
+
+    client = AzureOpenAI(
+        azure_endpoint=endpoint,
+        api_key=api_key,
+        api_version=api_version,
+    )
+
+    last_error: Exception | None = None
+    for attempt in range(3):
+        try:
+            resp = client.chat.completions.create(
+                model=deployment,
+                messages=[
+                    {"role": "system", "content": system},
+                    {"role": "user", "content": user},
+                ],
+                response_format={"type": "json_object"},
+                temperature=0.1,
+                max_completion_tokens=6000,
+            )
+            return resp.choices[0].message.content or "{}"
+        except Exception as exc:
+            last_error = exc
+            if attempt < 2:
+                time.sleep(8 * (attempt + 1))
+    raise RuntimeError(f"Azure OpenAI failed: {last_error}")
+
+
+def call_anthropic_fallback(system: str, user: str) -> str:
+    from anthropic import Anthropic
+
+    key = os.environ.get("ANTHROPIC_API_KEY", "")
+    if not key:
+        raise RuntimeError("ANTHROPIC_API_KEY not set")
+
+    client = Anthropic(api_key=key)
+    resp = client.messages.create(
+        model="claude-opus-4-6",
+        max_tokens=6000,
+        system=[{"type": "text", "text": system, "cache_control": {"type": "ephemeral"}}],
+        messages=[{"role": "user", "content": user}],
+    )
+    parts: list[str] = []
+    for block in resp.content:
+        if getattr(block, "type", None) == "text":
+            parts.append(block.text)
+    raw = "".join(parts).strip()
+    if raw.startswith("```"):
+        raw = raw.strip("`")
+        if raw.lower().startswith("json\n"):
+            raw = raw[5:]
+    return raw
+
+
+def parse_response(raw: str) -> dict[str, Any]:
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        start = raw.find("{")
+        end = raw.rfind("}")
+        if start >= 0 and end > start:
+            try:
+                data = json.loads(raw[start : end + 1])
+            except json.JSONDecodeError:
+                return _empty_result("JSON parse failed")
+        else:
+            return _empty_result("No JSON found in response")
+
+    data.setdefault("summary", {"high": 0, "medium": 0, "low": 0})
+    data.setdefault("findings", [])
+    data.setdefault("positives", [])
+    data.setdefault("patches", [])
+    data.setdefault("overall_verdict", "COMMENT")
+    return data
+
+
+def _empty_result(error: str = "") -> dict[str, Any]:
+    return {
+        "summary": {"high": 0, "medium": 0, "low": 0},
+        "findings": [],
+        "positives": [],
+        "patches": [],
+        "overall_verdict": "APPROVE",
+        **({"error": error} if error else {}),
+    }
+
+
+def _merge_chunk_result(
+    aggregate: dict[str, Any],
+    chunk_result: dict[str, Any],
+    next_id: int,
+) -> int:
+    id_map: dict[str, str] = {}
+
+    for finding in chunk_result.get("findings", []):
+        old_id = str(finding.get("id") or f"finding-{next_id}")
+        new_id = f"SEC-{next_id:03d}"
+        next_id += 1
+        id_map[old_id] = new_id
+        finding["id"] = new_id
+        finding["confidence"] = _confidence(finding.get("confidence"))
+        aggregate["findings"].append(finding)
+
+    for patch in chunk_result.get("patches", []):
+        old_finding_id = str(patch.get("finding_id", ""))
+        if old_finding_id in id_map:
+            patch["finding_id"] = id_map[old_finding_id]
+            aggregate["patches"].append(patch)
+
+    for positive in chunk_result.get("positives", []):
+        if positive not in aggregate["positives"]:
+            aggregate["positives"].append(positive)
+
+    return next_id
+
+
+def validate_patches(
+    patches_raw: list[dict[str, Any]],
+    file_contents: dict[str, str],
+    changed_paths: set[str],
+    findings: list[dict[str, Any]],
+    max_patches: int,
+) -> list[Patch]:
+    findings_by_id = {str(f.get("id")): f for f in findings}
+    valid: list[Patch] = []
+
+    for i, patch_raw in enumerate(patches_raw):
+        if len(valid) >= max_patches:
+            print(f"  Patch {i}: SKIP - max patch count reached")
+            break
+
+        finding_id = str(patch_raw.get("finding_id", ""))
+        finding = findings_by_id.get(finding_id)
+        filepath = str(patch_raw.get("file", "")).lstrip("./")
+        search = str(patch_raw.get("search", ""))
+        replace = str(patch_raw.get("replace", ""))
+        reason = str(patch_raw.get("reason", ""))
+
+        if not finding:
+            print(f"  Patch {i}: SKIP - no surviving finding for {finding_id}")
+            continue
+        if str(finding.get("severity", "")).upper() not in {"HIGH", "MEDIUM"}:
+            print(f"  Patch {i}: SKIP - severity is not HIGH/MEDIUM")
+            continue
+        if _confidence(finding.get("confidence")) < MIN_PATCH_CONFIDENCE:
+            print(f"  Patch {i}: SKIP - confidence below {MIN_PATCH_CONFIDENCE}")
+            continue
+        if not filepath or not search or not replace:
+            print(f"  Patch {i}: SKIP - missing file/search/replace")
+            continue
+        if not _is_patchable_path(filepath, changed_paths):
+            print(f"  Patch {i}: SKIP - {filepath} is not patchable")
+            continue
+        if filepath not in file_contents:
+            print(f"  Patch {i}: SKIP - {filepath} not fetched")
+            continue
+        count = file_contents[filepath].count(search)
+        if count == 0:
+            print(f"  Patch {i}: SKIP - search string not found in {filepath}")
+            continue
+        if count > 1:
+            print(f"  Patch {i}: SKIP - search string ambiguous in {filepath}")
+            continue
+        if search == replace:
+            print(f"  Patch {i}: SKIP - no-op patch")
+            continue
+        if len(replace) > max(12_000, len(search) * 8):
+            print(f"  Patch {i}: SKIP - replacement too large for safe auto-fix")
+            continue
+
+        print(f"  Patch {i}: VALID - {filepath} ({reason})")
+        valid.append(Patch(file=filepath, search=search, replace=replace, finding_id=finding_id, reason=reason))
+
+    return valid
+
+
+def write_patches_to_workspace(file_contents: dict[str, str], patches: list[Patch]) -> None:
+    modified = apply_to_contents(file_contents, patches)
+    root = Path.cwd().resolve()
+    for filepath, content in modified.items():
+        target = (root / filepath).resolve()
+        if root not in target.parents and target != root:
+            raise ValueError(f"Refusing to write outside workspace: {filepath}")
+        target.write_text(content)
+
+
+def run_validation(command: str) -> tuple[bool, str]:
+    if not command.strip():
+        return True, ""
+    proc = subprocess.run(
+        command,
+        shell=True,
+        cwd=Path.cwd(),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=300,
+    )
+    output = proc.stdout[-4000:] if proc.stdout else ""
+    return proc.returncode == 0, output
+
+
+def format_comment(result: dict[str, Any], patches_applied: list[Patch], commit_sha: str | None) -> str:
+    summary = result["summary"]
+    findings = result["findings"]
+    positives = result.get("positives", [])
+    verdict = result.get("overall_verdict", "COMMENT")
+    verdict_label = {"APPROVE": "PASS", "COMMENT": "INFO", "REQUEST_CHANGES": "BLOCKING"}.get(verdict, "INFO")
+
+    lines: list[str] = [
+        "[![Agent Mag](https://theagentmag.com/brand/agentmag-banner-github.png)](https://theagentmag.com)",
+        "",
+        "## PR Security Auto-Fix Review",
+        "",
+        f"**Verdict**: `{verdict_label}` - {verdict}",
+        f"**Findings**: {summary.get('high', 0)} high · {summary.get('medium', 0)} medium · {summary.get('low', 0)} low",
+    ]
+
+    if result.get("model_used"):
+        lines.append(f"**Model**: {result['model_used']}")
+
+    if patches_applied:
+        lines.append(f"**Auto-fixed**: {len(patches_applied)} patch{'es' if len(patches_applied) != 1 else ''} applied")
+        if commit_sha:
+            lines.append(f"**Fix commit**: `{commit_sha[:7]}`")
+    lines.append("")
+
+    if result.get("skipped_reason"):
+        lines.append(f":warning: {result['skipped_reason']}")
+        lines.append("")
+
+    if patches_applied:
+        lines.append("### Auto-applied fixes")
+        lines.append("")
+        for patch in patches_applied:
+            label = f"{patch.finding_id}: " if patch.finding_id else ""
+            lines.append(f"- `{patch.file}` - {label}{patch.reason or 'security patch'}")
+        lines.append("")
+        lines.append("> Review the fix commit. If anything looks wrong, revert that commit.")
+        lines.append("")
+
+    if positives:
+        lines.append("### Secure patterns in this PR")
+        for positive in positives[:5]:
+            lines.append(f"- {positive}")
+        lines.append("")
+
+    if findings:
+        lines.append("### Remaining findings")
+        lines.append("")
+        lines.append("| Sev | Conf | Category | Rule | File |")
+        lines.append("|---|---:|---|---|---|")
+        for finding in findings[:25]:
+            sev = finding.get("severity", "")
+            confidence = _confidence(finding.get("confidence"))
+            category = finding.get("category", "")
+            rule = finding.get("rule", "")
+            file_path = finding.get("file", "")
+            line = finding.get("line")
+            loc = f"`{file_path}`{f':{line}' if line else ''}"
+            lines.append(f"| {sev} | {confidence:.2f} | {category} | `{rule}` | {loc} |")
+        if len(findings) > 25:
+            lines.append("")
+            lines.append(f"_... and {len(findings) - 25} more in the JSON artifact._")
+        lines.append("")
+
+        lines.append("<details><summary>Finding details</summary>")
+        lines.append("")
+        for finding in findings:
+            lines.append(f"#### `{finding.get('severity', '')}` - {finding.get('id', '')}: {finding.get('rule', '')}")
+            lines.append(f"**File**: `{finding.get('file', '')}`" + (f" (line {finding.get('line')})" if finding.get("line") else ""))
+            lines.append("")
+            lines.append(f"**Issue**: {finding.get('issue', '')}")
+            lines.append("")
+            lines.append(f"**Exploit scenario**: {finding.get('exploit_scenario', '')}")
+            lines.append("")
+            lines.append(f"**Recommendation**: {finding.get('recommendation', '')}")
+            lines.append("")
+        lines.append("</details>")
+        lines.append("")
+
+    if not findings and not patches_applied and not result.get("skipped_reason"):
+        lines.append("No high-confidence security findings in the changed files.")
+
+    if result.get("patch_error"):
+        lines.append("")
+        lines.append(f":warning: Auto-fix skipped: `{result['patch_error']}`")
+
+    lines.extend([
+        "",
+        "---",
+        "",
+        "<sub>Powered by [Agent Mag](https://theagentmag.com) PR Security Auto-Fix · GPT-5.4 specialist · [Get this tool](https://theagentmag.com/tools/pr-security-auto-fix)</sub>",
+    ])
+    return "\n".join(lines)
+
+
+def post_comment(pr: PullRequest, body: str) -> None:
+    for comment in pr.get_issue_comments():
+        if comment.body and COMMENT_MARKER in comment.body:
+            comment.edit(COMMENT_MARKER + "\n" + body)
+            return
+    pr.create_issue_comment(COMMENT_MARKER + "\n" + body)
+
+
+def _write_outputs(count: int, summary: dict[str, int], verdict: str) -> None:
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if not output_path:
+        return
+    with open(output_path, "a") as handle:
+        handle.write(f"findings_count={count}\n")
+        handle.write(f"summary={summary['high']} high / {summary['medium']} medium / {summary['low']} low\n")
+        handle.write(f"verdict={verdict}\n")
+
+
+def _write_result(result: dict[str, Any]) -> None:
+    Path(RESULTS_FILE).write_text(json.dumps(result, indent=2))
+
+
+def main() -> int:
+    token = os.environ["GITHUB_TOKEN"]
+    repo_full = os.environ["GITHUB_REPOSITORY"]
+    pr_number = int(os.environ["PR_NUMBER"])
+    should_comment = _env_bool("COMMENT_PR", True)
+    auto_fix = _env_bool("AUTO_FIX", True)
+    trusted_only = _env_bool("TRUSTED_ONLY", True)
+    max_patches = max(0, _env_int("MAX_PATCHES", 5))
+    validation_command = os.environ.get("VALIDATION_COMMAND", "").strip()
+    exclude_dirs = _normalize_exclude_dirs(os.environ.get("EXCLUDE_DIRECTORIES", ""))
+    chunk_max_chars = _env_int("SECURITY_CHUNK_MAX_CHARS", 32_000)
+    action_path = os.environ.get("ACTION_PATH", os.path.dirname(os.path.abspath(__file__)))
+
+    gh = Github(token)
+    repo = gh.get_repo(repo_full)
+    pr = repo.get_pull(pr_number)
+    head_ref = pr.head.ref
+    head_sha = pr.head.sha
+    head_repo = pr.head.repo.full_name if pr.head.repo else repo_full
+    is_trusted = head_repo == repo_full
+
+    if not is_trusted and trusted_only:
+        result = _empty_result("Skipped untrusted PR")
+        result["skipped_reason"] = "Review skipped because this PR comes from a fork and `trusted-only` is enabled."
+        result["overall_verdict"] = "COMMENT"
+        _write_result(result)
+        if should_comment:
+            post_comment(pr, format_comment(result, [], None))
+        _write_outputs(0, result["summary"], result["overall_verdict"])
+        return 0
+
+    if not is_trusted:
+        print("Untrusted/fork PR detected. Disabling auto-fix.")
+        auto_fix = False
+
+    raw_files = list(pr.get_files())
+    files_as_dicts = [
+        {
+            "filename": file.filename,
+            "patch": file.patch,
+            "status": file.status,
+            "additions": file.additions,
+            "deletions": file.deletions,
+        }
+        for file in raw_files
+    ]
+    relevant_files = filter_changed_files(files_as_dicts, exclude_dirs)
+
+    if not relevant_files:
+        result = _empty_result()
+        result["skipped_reason"] = "No security-relevant changed files were found."
+        result["overall_verdict"] = "APPROVE"
+        _write_result(result)
+        if should_comment:
+            post_comment(pr, format_comment(result, [], None))
+        _write_outputs(0, result["summary"], result["overall_verdict"])
+        return 0
+
+    changed_paths = [str(file["filename"]) for file in relevant_files]
+    changed_path_set = set(changed_paths)
+    print(f"Fetching full contents for {len(changed_paths)} changed files...")
+    file_contents = fetch_file_contents(repo, head_sha, changed_paths)
+    relevant_files = [file for file in relevant_files if file["filename"] in file_contents]
+
+    rulebook = load_rulebook(action_path)
+    custom_scan = read_optional_instruction(action_path, os.environ.get("CUSTOM_SECURITY_SCAN_INSTRUCTIONS", ""))
+    false_positive_scan = read_optional_instruction(action_path, os.environ.get("FALSE_POSITIVE_FILTERING_INSTRUCTIONS", ""))
+
+    aggregate = _empty_result()
+    aggregate["overall_verdict"] = "COMMENT"
+    aggregate["chunks"] = []
+    next_id = 1
+    model_used = "none"
+
+    chunks = chunk_files(relevant_files, file_contents, chunk_max_chars)
+    print(f"Reviewing {len(relevant_files)} files in {len(chunks)} chunk(s).")
+
+    for index, chunk in enumerate(chunks, start=1):
+        chunk_paths = [str(file["filename"]) for file in chunk]
+        chunk_contents = {path: file_contents[path] for path in chunk_paths if path in file_contents}
+        diff_text = build_diff_text(chunk)
+        user_prompt = build_user_prompt(
+            repo_full_name=repo_full,
+            pr_title=pr.title or "",
+            pr_body=pr.body or "",
+            pr_number=pr_number,
+            diff_text=diff_text,
+            changed_files=chunk_paths,
+            file_contents=chunk_contents,
+            rulebook=rulebook,
+            custom_scan_instructions=custom_scan,
+            false_positive_instructions=false_positive_scan,
+        )
+
+        raw = ""
+        try:
+            raw = call_azure_openai(SYSTEM_PROMPT, user_prompt)
+            model_used = "azure-gpt-5.4"
+        except Exception as azure_error:
+            print(f"Azure OpenAI failed on chunk {index}: {azure_error}. Trying Anthropic fallback...")
+            try:
+                raw = call_anthropic_fallback(SYSTEM_PROMPT, user_prompt)
+                model_used = "anthropic-claude-opus-4.6"
+            except Exception as anthropic_error:
+                print(f"Anthropic fallback failed on chunk {index}: {anthropic_error}")
+                aggregate.setdefault("model_errors", []).append(
+                    {
+                        "chunk": index,
+                        "azure_error": str(azure_error),
+                        "anthropic_error": str(anthropic_error),
+                    }
+                )
+                continue
+
+        chunk_result = parse_response(raw)
+        if chunk_result.get("error"):
+            aggregate.setdefault("model_errors", []).append(
+                {"chunk": index, "parse_error": chunk_result.get("error")}
+            )
+        next_id = _merge_chunk_result(aggregate, chunk_result, next_id)
+        aggregate["chunks"].append({"index": index, "files": chunk_paths})
+
+    aggregate["model_used"] = model_used
+    if not aggregate["chunks"] and aggregate.get("model_errors"):
+        aggregate["skipped_reason"] = "Review skipped because all model calls failed or returned invalid JSON."
+        aggregate["overall_verdict"] = "COMMENT"
+        _write_result(aggregate)
+        if should_comment:
+            post_comment(pr, format_comment(aggregate, [], None))
+        _write_outputs(0, aggregate["summary"], aggregate["overall_verdict"])
+        return 0
+
+    aggregate["findings"] = filter_findings(aggregate.get("findings", []))
+    aggregate["summary"] = recount_summary(aggregate["findings"])
+    aggregate["overall_verdict"] = compute_verdict(aggregate["summary"])
+
+    raw_patches = aggregate.get("patches", [])
+    patches_applied: list[Patch] = []
+    commit_sha: str | None = None
+    print(f"Model returned {len(aggregate['findings'])} findings and {len(raw_patches)} candidate patches.")
+
+    if auto_fix and raw_patches and max_patches > 0:
+        valid_patches = validate_patches(
+            raw_patches,
+            file_contents,
+            changed_path_set,
+            aggregate["findings"],
+            max_patches,
+        )
+        print(f"{len(valid_patches)} patches passed validation.")
+        if valid_patches:
+            try:
+                if validation_command:
+                    print(f"Applying patches locally and running validation: {validation_command}")
+                    write_patches_to_workspace(file_contents, valid_patches)
+                    ok, output = run_validation(validation_command)
+                    aggregate["validation_command"] = validation_command
+                    aggregate["validation_output"] = output
+                    if not ok:
+                        raise RuntimeError("validation command failed")
+
+                commit_sha = apply_patches(
+                    repo=repo,
+                    branch=head_ref,
+                    base_sha=head_sha,
+                    patches=valid_patches,
+                    file_contents=file_contents,
+                    commit_message=(
+                        "fix(security): auto-fix PR security issues\n\n"
+                        "Applied by Agent Mag PR Security Auto-Fix.\n"
+                        "Patched files: " + ", ".join(sorted({patch.file for patch in valid_patches}))
+                    ),
+                )
+                patches_applied = valid_patches
+                print(f"Committed fixes: {commit_sha}")
+            except Exception as exc:
+                print(f"Failed to apply patches: {exc}")
+                aggregate["patch_error"] = str(exc)
+
+    if patches_applied:
+        patched_finding_ids = {patch.finding_id for patch in patches_applied if patch.finding_id}
+        aggregate["findings"] = [
+            finding for finding in aggregate["findings"]
+            if str(finding.get("id", "")) not in patched_finding_ids
+        ]
+        aggregate["summary"] = recount_summary(aggregate["findings"])
+        aggregate["overall_verdict"] = compute_verdict(aggregate["summary"])
+
+    aggregate["patches_applied"] = [
+        {"finding_id": patch.finding_id, "file": patch.file, "reason": patch.reason}
+        for patch in patches_applied
+    ]
+    aggregate["fix_commit"] = commit_sha
+    _write_result(aggregate)
+
+    if should_comment:
+        post_comment(pr, format_comment(aggregate, patches_applied, commit_sha))
+
+    _write_outputs(len(aggregate["findings"]), aggregate["summary"], aggregate["overall_verdict"])
+    print(
+        "PR Security Auto-Fix complete. "
+        f"Findings: {len(aggregate['findings'])}. "
+        f"Patches: {len(patches_applied)}. Model: {model_used}."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pr-security-auto-fix/rules/auto-fix.md
+++ b/pr-security-auto-fix/rules/auto-fix.md
@@ -1,0 +1,26 @@
+# Auto-Fix Rules
+
+Auto-fix only safe, local, low-risk issues.
+
+## Allowed Patches
+
+1. Parameterize or escape a query when the local database API pattern is clear.
+2. Add or restore a missing server-side authorization check when nearby code shows the intended helper.
+3. Remove, redact, or narrow sensitive logging.
+4. Validate URL host/protocol before a server-side fetch.
+5. Restrict permissive CORS or redirect allowlists.
+6. Replace an unsafe rendering sink with escaped text or an existing sanitizer.
+7. Add input validation immediately before a dangerous sink.
+8. Fix unsafe GitHub Actions shell interpolation when the safe environment-variable pattern is obvious.
+
+## Disallowed Patches
+
+1. Do not add new dependencies.
+2. Do not rewrite broad architecture.
+3. Do not guess business authorization policy.
+4. Do not edit tests, docs, lockfiles, generated files, public assets, or workflow files.
+5. Do not disable security controls, lint rules, type checks, or tests.
+6. Do not delete functionality just to remove a finding.
+7. Do not produce a patch unless the exact `search` string appears once in the file.
+
+If the issue is real but the safe fix is not obvious, report the finding without a patch.

--- a/pr-security-auto-fix/rules/false-positives.md
+++ b/pr-security-auto-fix/rules/false-positives.md
@@ -1,0 +1,18 @@
+# False Positive Rules
+
+Exclude these from findings unless there is an unusually direct and high-impact exploit path.
+
+1. Denial of service, rate limiting, memory exhaustion, CPU exhaustion, regex DoS, and resource leaks.
+2. Missing audit logs or monitoring.
+3. Documentation-only concerns.
+4. Test-only or fixture-only code.
+5. Generic lack of validation without security impact.
+6. Open redirects, tabnabbing, XS-Leaks, log spoofing, and clickjacking.
+7. Outdated dependencies or known CVEs.
+8. React, Angular, or Vue rendering of normal escaped text.
+9. Client-side authorization checks unless server-side code also trusts them.
+10. Attacks requiring control of trusted environment variables, deployment config, or repository secrets.
+11. Prompt injection claims where no privileged tool, secret, or sensitive data can be reached.
+12. Shell script injection unless untrusted runtime input reaches the script in CI or production.
+
+Only include MEDIUM findings when the exploit is concrete and actionable.

--- a/pr-security-auto-fix/rules/language-patterns.md
+++ b/pr-security-auto-fix/rules/language-patterns.md
@@ -1,0 +1,24 @@
+# Language And Framework Patterns
+
+## JavaScript / TypeScript / Next.js
+
+- API routes, route handlers, server actions, and middleware/proxy files are security-sensitive.
+- Do not report ordinary React interpolation as XSS.
+- Report `dangerouslySetInnerHTML`, `innerHTML`, `eval`, `new Function`, command execution, unsafe redirects, public server-side fetches, and server-side auth bypasses when attacker-controlled input reaches them.
+- For MongoDB, report direct use of untrusted objects in query operators when the code does not normalize to expected scalar fields.
+
+## Python
+
+- Report unsafe `subprocess` with `shell=True`, `pickle`, unsafe YAML loading, path traversal, SQL string interpolation, SSRF, and auth bypasses.
+- Do not report command injection in scripts unless they process untrusted runtime input.
+
+## GitHub Actions
+
+- Prefer environment variables over direct expression interpolation inside shell scripts.
+- Report `pull_request_target` only when combined with checking out or executing untrusted PR code with write/secrets permissions.
+- Report script execution from PR-controlled strings only when the path is concrete.
+
+## Infrastructure
+
+- Report public debug/admin surfaces, permissive CORS with credentials, disabled TLS/certificate validation, and secret material committed into config.
+- Do not report broad best-practice hardening without an exploit path.

--- a/pr-security-auto-fix/rules/security-review.md
+++ b/pr-security-auto-fix/rules/security-review.md
@@ -1,0 +1,28 @@
+# Security Review Rules
+
+Review only vulnerabilities introduced or materially changed by the pull request.
+
+## Reportable Findings
+
+1. Injection into SQL, NoSQL, shell commands, templates, XML parsers, deserializers, file paths, or GraphQL resolvers.
+2. Server-side authorization bypass, tenant isolation bypass, privilege escalation, or trusting client-controlled role/user identifiers.
+3. Authentication bypass, unsafe session/token validation, missing signature checks, or predictable security tokens.
+4. Sensitive data exposure to client responses, logs, public artifacts, error messages, or analytics payloads.
+5. XSS only when an unsafe rendering sink exists, such as `dangerouslySetInnerHTML`, `innerHTML`, template bypass APIs, or direct HTML construction.
+6. SSRF only when attacker input can control the host, protocol, or internal network target.
+7. Weak crypto only when it protects security-sensitive data or auth state.
+8. Insecure configuration that exposes admin/debug functionality or secrets.
+9. GitHub Actions risks only when untrusted PR/user data can reach script execution, secret access, or privileged writes.
+10. AI-agent risks only when untrusted model/user output can reach privileged tools, filesystem writes, network requests, shell commands, or secrets.
+
+## Required Evidence
+
+Each finding must include:
+
+- A changed file path and line number when available.
+- A specific source of attacker-controlled input.
+- A specific sink or privileged operation.
+- A realistic exploit scenario.
+- A concrete fix recommendation.
+
+Do not report issues without a clear source-to-sink path.


### PR DESCRIPTION
## Summary
- Adds `pr-security-auto-fix`, an Agent Mag GitHub Action for AI-powered PR security review and safe auto-fix commits.
- Includes GPT-5.4 primary model support, Claude fallback, trusted-PR guardrails, chunked review, structured findings, and branded PR comments.
- Adds security rulebooks and documents the `npx agentmag add tool pr-security-auto-fix` install path.

## Why
Teams want the same auto-fix workflow we have for SEO/GEO, but focused on high-confidence PR security issues: injection, auth bypass, data exposure, XSS, SSRF, unsafe config, and AI-agent tool risks. This gives Agent Mag a public, SEO-friendly security tool surface in the tools repo.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile pr-security-auto-fix/*.py`

## Caveats
- Public users must provide their own Azure OpenAI or Anthropic secrets.
- Auto-fix is restricted to trusted PRs by default and exact-match patch validation; forked PRs are skipped unless explicitly configured otherwise.
