### PR TITLE
Add Dot Matrix tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ This is the home for **free, open-source tools** built by and for the AI agent b
 |------|-------------|---------|
 | **[SEO/GEO Auto-Fix Reviewer](seo-geo-reviewer/)** | AI-powered GitHub Action that reviews PRs for SEO issues and auto-fixes them. Uses GPT-5.4 or Claude. | `npx agentmag add tool seo-geo-reviewer` |
 | **[PR Security Auto-Fix](pr-security-auto-fix/)** | AI-powered GitHub Action that reviews pull requests for security issues and commits safe fixes automatically. Uses GPT-5.4 or Claude. | `npx agentmag add tool pr-security-auto-fix` |
+| **[Dot Matrix Icons](dot-matrix/)** | Animated 5x5 SVG loaders for agent interfaces, status states, and product UI. | `npx agentmag add tool dotmatrix-icons` |
 | **[Agent Sounds](agent-sounds/)** | Sound effects for Claude Code sessions — hear audio cues when tasks start, complete, or need attention. 4 original royalty-free sound packs. | `npx agentmag add tool claude-sounds` |
 
 ---

--- a/dot-matrix/README.md
+++ b/dot-matrix/README.md
@@ -1,0 +1,49 @@
+# Dot Matrix Icons
+
+Animated 5x5 SVG loaders for agent interfaces, product tools, status states, and compact dashboards.
+
+This is the open-source source package behind:
+
+- `https://dotmatrix.theagentmag.com`
+- `https://theagentmag.com/tools/dotmatrix`
+- `npx agentmag add tool dotmatrix-icons`
+
+## Install From Agent Mag CLI
+
+```bash
+npx agentmag add tool dotmatrix-icons
+```
+
+The CLI writes a local React bundle into `components/dotmatrix/`:
+
+```txt
+components/dotmatrix/
+  registry.ts
+  dotmatrix-icon.tsx
+  dotmatrix.css
+  index.ts
+  README.md
+```
+
+## Usage
+
+```tsx
+import "@/components/dotmatrix/dotmatrix.css"
+import { DotMatrixIcon } from "@/components/dotmatrix"
+
+export function ToolCallLoader() {
+  return <DotMatrixIcon pattern="agent-thinking" size={40} color="currentColor" />
+}
+```
+
+## What Is Included
+
+- 72 animated 5x5 dot-matrix loaders
+- Spinner, progress, ambient, agent, and status categories
+- Copyable SVG output on the Agent Mag microsite
+- React component, CSS keyframes, and registry data
+- Pause, tint, speed, and density controls on the web surface
+
+## License
+
+MIT. See the repository root license.

--- a/dot-matrix/package.json
+++ b/dot-matrix/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@agentmag/dot-matrix-icons",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Animated 5x5 SVG loaders for agent interfaces.",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.tsx",
+    "./css": "./src/dotmatrix.css"
+  },
+  "peerDependencies": {
+    "react": ">=18"
+  }
+}

--- a/dot-matrix/src/dotmatrix.css
+++ b/dot-matrix/src/dotmatrix.css
@@ -1,0 +1,37 @@
+.dotmatrix-icon [data-dot-bg] {
+  opacity: 0.16;
+}
+
+.dotmatrix-icon [data-dot] {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation-duration: var(--dotmatrix-duration, 1200ms);
+  animation-delay: var(--dotmatrix-delay, 0ms);
+  animation-iteration-count: infinite;
+  animation-timing-function: ease-in-out;
+  animation-play-state: var(--dotmatrix-play-state, running);
+}
+
+.dotmatrix-icon[data-motion="orbit"] [data-dot] { animation-name: dotmatrix-orbit; }
+.dotmatrix-icon[data-motion="scan"] [data-dot] { animation-name: dotmatrix-scan; }
+.dotmatrix-icon[data-motion="wave"] [data-dot] { animation-name: dotmatrix-wave; }
+.dotmatrix-icon[data-motion="ripple"] [data-dot] { animation-name: dotmatrix-ripple; }
+.dotmatrix-icon[data-motion="spark"] [data-dot] { animation-name: dotmatrix-spark; }
+.dotmatrix-icon[data-motion="march"] [data-dot] { animation-name: dotmatrix-march; }
+.dotmatrix-icon[data-motion="breathe"] [data-dot] { animation-name: dotmatrix-breathe; }
+.dotmatrix-icon[data-motion="hold"] [data-dot] { animation-name: dotmatrix-hold; }
+
+@keyframes dotmatrix-orbit { 0%, 100% { opacity: .18; transform: scale(.7); } 45% { opacity: 1; transform: scale(1.08); } }
+@keyframes dotmatrix-scan { 0%, 100% { opacity: .16; transform: scale(.74); } 50% { opacity: 1; transform: scale(1); } }
+@keyframes dotmatrix-wave { 0%, 100% { opacity: .22; transform: translateY(0) scale(.78); } 50% { opacity: 1; transform: translateY(-1.5px) scale(1.06); } }
+@keyframes dotmatrix-ripple { 0%, 100% { opacity: .18; transform: scale(.66); } 55% { opacity: 1; transform: scale(1.12); } }
+@keyframes dotmatrix-spark { 0%, 100% { opacity: .16; transform: scale(.72); } 35% { opacity: 1; transform: scale(1.16); } 60% { opacity: .32; transform: scale(.84); } }
+@keyframes dotmatrix-march { 0%, 100% { opacity: .18; transform: translateX(0) scale(.78); } 50% { opacity: 1; transform: translateX(1.5px) scale(1.04); } }
+@keyframes dotmatrix-breathe { 0%, 100% { opacity: .32; transform: scale(.86); } 50% { opacity: 1; transform: scale(1.04); } }
+@keyframes dotmatrix-hold { 0%, 100% { opacity: .82; transform: scale(1); } 50% { opacity: 1; transform: scale(1.02); } }
+
+@media (prefers-reduced-motion: reduce) {
+  .dotmatrix-icon [data-dot] {
+    animation: none !important;
+  }
+}

--- a/dot-matrix/src/index.tsx
+++ b/dot-matrix/src/index.tsx
@@ -1,0 +1,80 @@
+"use client"
+
+import * as React from "react"
+import { dotMatrixPatterns, getDotMatrixPattern, gridCells, type DotMatrixPattern } from "./patterns"
+
+export type { DotMatrixCategory, DotMatrixMotion, DotMatrixPattern } from "./patterns"
+export { dotMatrixPatterns, getDotMatrixPattern }
+
+export interface DotMatrixIconProps extends Omit<React.SVGProps<SVGSVGElement>, "color"> {
+  pattern?: string | DotMatrixPattern
+  size?: number
+  color?: string
+  speed?: number
+  paused?: boolean
+  dotRadius?: number
+}
+
+export function DotMatrixIcon({
+  pattern = "agent-thinking",
+  size = 48,
+  color = "currentColor",
+  speed = 1,
+  paused = false,
+  dotRadius = 4.6,
+  className,
+  style,
+  "aria-label": ariaLabel,
+  ...props
+}: DotMatrixIconProps) {
+  const resolvedPattern = typeof pattern === "string" ? getDotMatrixPattern(pattern) : pattern
+  const duration = Math.max(240, Math.round(resolvedPattern.durationMs / Math.max(0.2, speed)))
+  const activeKeys = new Set(resolvedPattern.cells.map((cell) => `${cell.x}-${cell.y}`))
+
+  return (
+    <svg
+      viewBox="0 0 96 96"
+      width={size}
+      height={size}
+      role="img"
+      aria-label={ariaLabel || resolvedPattern.name}
+      data-motion={resolvedPattern.motion}
+      className={["dotmatrix-icon", className].filter(Boolean).join(" ")}
+      style={{
+        color,
+        "--dotmatrix-duration": `${duration}ms`,
+        "--dotmatrix-play-state": paused ? "paused" : "running",
+        ...style,
+      } as React.CSSProperties}
+      {...props}
+    >
+      {gridCells
+        .filter((cell) => !activeKeys.has(`${cell.x}-${cell.y}`))
+        .map((cell) => (
+          <circle
+            key={`base-${cell.x}-${cell.y}`}
+            data-dot-bg=""
+            cx={12 + cell.x * 18}
+            cy={12 + cell.y * 18}
+            r={dotRadius}
+            fill="currentColor"
+          />
+        ))}
+      {resolvedPattern.cells.map((cell) => (
+        <circle
+          key={`${cell.x}-${cell.y}`}
+          data-dot=""
+          cx={12 + cell.x * 18}
+          cy={12 + cell.y * 18}
+          r={dotRadius}
+          fill="currentColor"
+          opacity={cell.opacity}
+          style={{
+            "--dotmatrix-delay": `${Math.round(cell.delay * duration * -1)}ms`,
+            "--dotmatrix-dot-scale": cell.scale ?? 1,
+          } as React.CSSProperties}
+        />
+      ))}
+    </svg>
+  )
+}

--- a/dot-matrix/src/patterns.ts
+++ b/dot-matrix/src/patterns.ts
@@ -1,0 +1,94 @@
+export type DotMatrixCategory = "spinner" | "progress" | "ambient" | "agent" | "status"
+export type DotMatrixMotion = "orbit" | "scan" | "wave" | "ripple" | "spark" | "march" | "breathe" | "hold"
+
+export interface DotMatrixCell {
+  x: number
+  y: number
+  opacity: number
+  delay: number
+  scale?: number
+}
+
+export interface DotMatrixPattern {
+  id: string
+  name: string
+  category: DotMatrixCategory
+  motion: DotMatrixMotion
+  family: "ring" | "line" | "field" | "agent" | "status"
+  tags: string[]
+  cells: DotMatrixCell[]
+  durationMs: number
+}
+
+export const gridCells = Array.from({ length: 25 }, (_, index) => ({
+  x: index % 5,
+  y: Math.floor(index / 5),
+}))
+
+type Seed = Omit<DotMatrixPattern, "cells" | "durationMs"> & {
+  rows: [string, string, string, string, string]
+  durationMs?: number
+}
+
+const center = 2
+const ordered = gridCells
+  .map((cell) => ({ ...cell, weight: Math.hypot(cell.x - center, cell.y - center) }))
+  .sort((a, b) => a.weight - b.weight)
+
+function normalize(index: number, length: number) {
+  return length <= 1 ? 0 : index / (length - 1)
+}
+
+function rowsToCells(rows: Seed["rows"], motion: DotMatrixMotion): DotMatrixCell[] {
+  const active = rows.flatMap((row, y) =>
+    row.split("").flatMap((value, x) => (value === "1" ? [{ x, y }] : []))
+  )
+
+  return active.map((cell, index) => {
+    const radial = Math.hypot(cell.x - center, cell.y - center)
+    const orderIndex = ordered.findIndex((item) => item.x === cell.x && item.y === cell.y)
+    const delay = motion === "ripple" ? normalize(orderIndex, ordered.length) : normalize(index, active.length)
+
+    return {
+      ...cell,
+      opacity: Math.max(0.64, 1 - radial * 0.1),
+      delay,
+      scale: 0.82 + Math.max(0, 1 - radial / 3) * 0.24,
+    }
+  })
+}
+
+const seeds: Seed[] = [
+  { id: "pulse-rings", name: "Pulse Rings", category: "spinner", family: "ring", motion: "ripple", tags: ["pulse", "ring"], rows: ["00100", "01110", "11111", "01110", "00100"] },
+  { id: "corner-orbit", name: "Corner Orbit", category: "spinner", family: "ring", motion: "orbit", tags: ["orbit", "perimeter"], rows: ["11111", "10001", "10001", "10001", "11111"] },
+  { id: "spiral-in", name: "Spiral In", category: "spinner", family: "ring", motion: "orbit", tags: ["spiral"], rows: ["11111", "00001", "11101", "10001", "11111"] },
+  { id: "cross-expand", name: "Cross Expand", category: "spinner", family: "ring", motion: "ripple", tags: ["cross"], rows: ["00100", "00100", "11111", "00100", "00100"] },
+  { id: "diamond-loop", name: "Diamond Loop", category: "spinner", family: "ring", motion: "orbit", tags: ["diamond"], rows: ["00100", "01010", "10001", "01010", "00100"] },
+  { id: "column-scan", name: "Column Scan", category: "progress", family: "line", motion: "scan", tags: ["column", "scan"], rows: ["10000", "10000", "10000", "10000", "10000"] },
+  { id: "row-scan", name: "Row Scan", category: "progress", family: "line", motion: "march", tags: ["row", "scan"], rows: ["00000", "00000", "11111", "00000", "00000"] },
+  { id: "diagonal-scan", name: "Diagonal Scan", category: "progress", family: "line", motion: "scan", tags: ["diagonal"], rows: ["10000", "01000", "00100", "00010", "00001"] },
+  { id: "pipeline", name: "Pipeline", category: "progress", family: "line", motion: "march", tags: ["pipeline"], rows: ["11111", "00000", "11111", "00000", "11111"] },
+  { id: "stream", name: "Stream", category: "progress", family: "line", motion: "wave", tags: ["stream"], rows: ["10000", "11000", "01110", "00011", "00001"] },
+  { id: "sparkle", name: "Sparkle", category: "ambient", family: "field", motion: "spark", tags: ["sparkle"], rows: ["10001", "00100", "01010", "00100", "10001"] },
+  { id: "rain", name: "Rain", category: "ambient", family: "field", motion: "wave", tags: ["rain"], rows: ["10101", "01010", "10101", "01010", "10101"] },
+  { id: "breathing-grid", name: "Breathing Grid", category: "ambient", family: "field", motion: "breathe", tags: ["grid"], rows: ["11111", "11111", "11111", "11111", "11111"] },
+  { id: "typing", name: "Typing", category: "ambient", family: "field", motion: "wave", tags: ["typing"], rows: ["00000", "00000", "01110", "00000", "00000"] },
+  { id: "agent-thinking", name: "Agent Thinking", category: "agent", family: "agent", motion: "ripple", tags: ["agent", "thinking"], rows: ["00100", "01110", "11011", "01110", "00100"] },
+  { id: "tool-call", name: "Tool Call", category: "agent", family: "agent", motion: "scan", tags: ["agent", "tool"], rows: ["11011", "10001", "00100", "10001", "11011"] },
+  { id: "memory-write", name: "Memory Write", category: "agent", family: "agent", motion: "march", tags: ["agent", "memory"], rows: ["11110", "10010", "11110", "10010", "11110"] },
+  { id: "retrieval-scan", name: "Retrieval Scan", category: "agent", family: "agent", motion: "orbit", tags: ["agent", "retrieval"], rows: ["00100", "10101", "01110", "10101", "00100"] },
+  { id: "verified", name: "Verified", category: "status", family: "status", motion: "hold", tags: ["status", "success"], rows: ["00001", "00010", "10100", "01000", "00000"], durationMs: 2200 },
+  { id: "blocked", name: "Blocked", category: "status", family: "status", motion: "breathe", tags: ["status", "blocked"], rows: ["11111", "10001", "10101", "10001", "11111"] },
+  { id: "queued", name: "Queued", category: "status", family: "status", motion: "march", tags: ["status", "queued"], rows: ["10000", "11000", "11100", "11000", "10000"] },
+  { id: "complete", name: "Complete", category: "status", family: "status", motion: "ripple", tags: ["status", "complete"], rows: ["00100", "01110", "11111", "01110", "00100"] },
+]
+
+export const dotMatrixPatterns: DotMatrixPattern[] = seeds.map((seed, index) => ({
+  ...seed,
+  durationMs: seed.durationMs ?? 980 + ((index * 71) % 640),
+  cells: rowsToCells(seed.rows, seed.motion),
+}))
+
+export function getDotMatrixPattern(id: string) {
+  return dotMatrixPatterns.find((pattern) => pattern.id === id) ?? dotMatrixPatterns[0]!
+}


### PR DESCRIPTION
## Summary
- Adds `dot-matrix/` as the Agent Mag-owned source package for Dot Matrix Icons.
- Documents the CLI install path: `npx agentmag add tool dotmatrix-icons`.
- Adds the tool to the public tools repo README.

## Why
Dot Matrix needs to exist as an Agent Mag open-source tool, not as a visible wrapper around another repo. This gives the website and CLI a canonical source path under `Agent-mag/tools/dot-matrix`.

## Validation
- `git diff --check`

## Caveats
- The website/CLI PR in `Agent-mag/agentmag` links to this path; that link fully resolves after this PR lands on `main`.
