### PR TITLE
Update Dot Matrix renderer

### DIFF
--- a/dot-matrix/src/dotmatrix.css
+++ b/dot-matrix/src/dotmatrix.css
@@ -1,8 +1,9 @@
 .dotmatrix-icon [data-dot-bg] {
-  opacity: 0.16;
+  opacity: 0.08;
 }
 
 .dotmatrix-icon [data-dot] {
+  opacity: 0;
   transform-box: fill-box;
   transform-origin: center;
   animation-duration: var(--dotmatrix-duration, 1200ms);
@@ -21,17 +22,18 @@
 .dotmatrix-icon[data-motion="breathe"] [data-dot] { animation-name: dotmatrix-breathe; }
 .dotmatrix-icon[data-motion="hold"] [data-dot] { animation-name: dotmatrix-hold; }
 
-@keyframes dotmatrix-orbit { 0%, 100% { opacity: .18; transform: scale(.7); } 45% { opacity: 1; transform: scale(1.08); } }
-@keyframes dotmatrix-scan { 0%, 100% { opacity: .16; transform: scale(.74); } 50% { opacity: 1; transform: scale(1); } }
-@keyframes dotmatrix-wave { 0%, 100% { opacity: .22; transform: translateY(0) scale(.78); } 50% { opacity: 1; transform: translateY(-1.5px) scale(1.06); } }
-@keyframes dotmatrix-ripple { 0%, 100% { opacity: .18; transform: scale(.66); } 55% { opacity: 1; transform: scale(1.12); } }
-@keyframes dotmatrix-spark { 0%, 100% { opacity: .16; transform: scale(.72); } 35% { opacity: 1; transform: scale(1.16); } 60% { opacity: .32; transform: scale(.84); } }
-@keyframes dotmatrix-march { 0%, 100% { opacity: .18; transform: translateX(0) scale(.78); } 50% { opacity: 1; transform: translateX(1.5px) scale(1.04); } }
-@keyframes dotmatrix-breathe { 0%, 100% { opacity: .32; transform: scale(.86); } 50% { opacity: 1; transform: scale(1.04); } }
-@keyframes dotmatrix-hold { 0%, 100% { opacity: .82; transform: scale(1); } 50% { opacity: 1; transform: scale(1.02); } }
+@keyframes dotmatrix-orbit { 0% { opacity: 0; transform: scale(.72); } 8% { opacity: 1; transform: scale(1.08); } 36% { opacity: .06; transform: scale(.82); } 100% { opacity: 0; transform: scale(.72); } }
+@keyframes dotmatrix-scan { 0% { opacity: 0; transform: scale(.74); } 6% { opacity: 1; transform: scale(1); } 30% { opacity: .08; transform: scale(.82); } 100% { opacity: 0; transform: scale(.74); } }
+@keyframes dotmatrix-wave { 0% { opacity: .05; transform: translateY(0) scale(.78); } 20% { opacity: 1; transform: translateY(-1.5px) scale(1.06); } 55% { opacity: .18; transform: translateY(0) scale(.86); } 100% { opacity: .05; transform: translateY(0) scale(.78); } }
+@keyframes dotmatrix-ripple { 0% { opacity: 0; transform: scale(.66); } 8% { opacity: 1; transform: scale(1.12); } 36% { opacity: .05; transform: scale(.82); } 100% { opacity: 0; transform: scale(.66); } }
+@keyframes dotmatrix-spark { 0% { opacity: .05; transform: scale(.72); } 40% { opacity: .05; transform: scale(.72); } 50% { opacity: 1; transform: scale(1.16); } 60% { opacity: .08; transform: scale(.84); } 100% { opacity: .05; transform: scale(.72); } }
+@keyframes dotmatrix-march { 0% { opacity: 0; transform: translateX(0) scale(.78); } 8% { opacity: 1; transform: translateX(1.5px) scale(1.04); } 42% { opacity: .08; transform: translateX(0) scale(.84); } 100% { opacity: 0; transform: translateX(0) scale(.78); } }
+@keyframes dotmatrix-breathe { 0%, 100% { opacity: .12; transform: scale(.86); } 50% { opacity: 1; transform: scale(1.04); } }
+@keyframes dotmatrix-hold { 0%, 100% { opacity: .18; transform: scale(1); } 50% { opacity: 1; transform: scale(1.02); } }
 
 @media (prefers-reduced-motion: reduce) {
   .dotmatrix-icon [data-dot] {
     animation: none !important;
+    opacity: 0.45;
   }
 }

--- a/dot-matrix/src/index.tsx
+++ b/dot-matrix/src/index.tsx
@@ -29,7 +29,6 @@ export function DotMatrixIcon({
 }: DotMatrixIconProps) {
   const resolvedPattern = typeof pattern === "string" ? getDotMatrixPattern(pattern) : pattern
   const duration = Math.max(240, Math.round(resolvedPattern.durationMs / Math.max(0.2, speed)))
-  const activeKeys = new Set(resolvedPattern.cells.map((cell) => `${cell.x}-${cell.y}`))
 
   return (
     <svg
@@ -48,18 +47,16 @@ export function DotMatrixIcon({
       } as React.CSSProperties}
       {...props}
     >
-      {gridCells
-        .filter((cell) => !activeKeys.has(`${cell.x}-${cell.y}`))
-        .map((cell) => (
-          <circle
-            key={`base-${cell.x}-${cell.y}`}
-            data-dot-bg=""
-            cx={12 + cell.x * 18}
-            cy={12 + cell.y * 18}
-            r={dotRadius}
-            fill="currentColor"
-          />
-        ))}
+      {gridCells.map((cell) => (
+        <circle
+          key={`base-${cell.x}-${cell.y}`}
+          data-dot-bg=""
+          cx={12 + cell.x * 18}
+          cy={12 + cell.y * 18}
+          r={dotRadius}
+          fill="currentColor"
+        />
+      ))}
       {resolvedPattern.cells.map((cell) => (
         <circle
           key={`${cell.x}-${cell.y}`}
@@ -70,7 +67,7 @@ export function DotMatrixIcon({
           fill="currentColor"
           opacity={cell.opacity}
           style={{
-            "--dotmatrix-delay": `${Math.round(cell.delay * duration * -1)}ms`,
+            "--dotmatrix-delay": `${Math.round(cell.delay * duration)}ms`,
             "--dotmatrix-dot-scale": cell.scale ?? 1,
           } as React.CSSProperties}
         />


### PR DESCRIPTION
## Summary
- Updates the public Dot Matrix renderer to match the polished Agent Mag gallery behavior.
- Keeps the package CSS aligned with the dashboard/CLI animation changes.

## Why
The website and CLI now use dim base dots plus lit overlay dots, improved timing, and the fixed speed-control behavior. The open-source package should render the same thing users see on Agent Mag.

## Validation
- `git diff --check`
